### PR TITLE
Refactor x coordinate calculation in DetectorService to use centroid …

### DIFF
--- a/lib/services/DetectorService.ts
+++ b/lib/services/DetectorService.ts
@@ -335,17 +335,13 @@ class DetectorService implements Service {
       const topViewDetectionImageURI = this.getCroppedImageURI(canvas, cropCanvas, pair.topView.box);
       const sideViewDetectionImageURI = this.getCroppedImageURI(canvas, cropCanvas, pair.sideView.box);
 
-      // Calculate raw x from ML detection box (physical leftward motion)
-      const xRaw = pair.topView.box.left + pair.topView.box.width / 2;
+      // Calculate x from ML detection box centroid
+      // Raw x already increases over time (rightward motion), matching findPositionAtTime's expectations
+      const centroidX = pair.topView.box.left + pair.topView.box.width / 2;
 
-      // Transform to canonical rightward coordinates
-      const xCanonical = videoWidth - xRaw;
-
-      // Log first 5 transformations for validation
+      // Log first 5 detections for validation
       if (index < 5) {
-        console.log(
-          `[COORD_TRANSFORM] detection ${index}: raw=${xRaw.toFixed(1)} → canonical=${xCanonical.toFixed(1)} (width=${videoWidth})`,
-        );
+        console.log(`[DETECTION] detection ${index}: x=${centroidX.toFixed(1)} (width=${videoWidth})`);
       }
 
       const topViewDetection: Detection = {
@@ -353,7 +349,7 @@ class DetectorService implements Service {
         imageURI: topViewDetectionImageURI,
         timestamp,
         centroid: {
-          x: xCanonical, // Use canonical x instead of raw x
+          x: centroidX, // Raw x increases over time (rightward motion)
           y: pair.topView.box.top + pair.topView.box.height / 2,
         },
         box: pair.topView.box,


### PR DESCRIPTION
…and improve logging clarity

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies coordinate handling and logs during detection.
> 
> - In `createDetections`, compute top-view `centroid.x` directly from the box centroid (`left + width/2`) and remove the previous right-to-left canonical flip (`videoWidth - xRaw`)
> - Replace transformation logs with concise detection logs for the first 5 items using `[DETECTION]` and centroid values
> - No changes to side-view centroid computation or other detection fields
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aba50844631a1f1a48579e3385c1b3803b731e69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->